### PR TITLE
Add meta option for ordering participants by name

### DIFF
--- a/streetcrm/migrations/0064_auto_20170801_2008.py
+++ b/streetcrm/migrations/0064_auto_20170801_2008.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('streetcrm', '0063_auto_20170404_1212'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='participant',
+            options={'ordering': ['name']},
+        ),
+    ]

--- a/streetcrm/models.py
+++ b/streetcrm/models.py
@@ -243,6 +243,9 @@ class Institution(ArchiveAbstract, SerializeableMixin):
 
 class Participant(ArchiveAbstract, SerializeableMixin):
     """ Representation of a person who can participate in a Event """
+    class Meta:
+        ordering = ['name']
+
     name = models.CharField(max_length=255, verbose_name="Participant Name")
     primary_phone = modelfields.PhoneNumberField(null=True, blank=True,
                                                  verbose_name="Participant Phone")


### PR DESCRIPTION
Added a default ordering option to the `Participant` model, so that the initial attendees on the sign-in page are in alphabetical order, but aren't reordered as the user enters more. Should close #304 

If there's any reason for not adding this to the meta options and the requirement is only for the sign in page, the other option would be adding `order_by('name')` to the query in `EventParticipantsAPI`. Let me know if there's anything I should change!