### PR TITLE
Adding search query and current date header row to CSV export

### DIFF
--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -656,7 +656,7 @@ class STREETCRMAdminSite(admin.AdminSite):
         last_header=[]
         header=[]
         
-        search_title = 'Created: {} - Query: {}'.format(
+        search_title = 'Exported on: {} - Search terms: {}'.format(
             filetime.strftime('%Y-%m-%d'), search_header
         )
         writer.writerow([search_title])

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -259,7 +259,7 @@ class STREETCRMAdminSite(admin.AdminSite):
         Returns counts of different result types for advanced search.
         """
         data = form.get_processed_data()
-        categorize = data["search_model"]
+        categorize = data["search_for"]
 
         major_event_count = None
         prep_event_count = None
@@ -304,7 +304,7 @@ class STREETCRMAdminSite(admin.AdminSite):
         This provides advanced searching options
         """
         data = form.get_processed_data()
-        categorize = data["search_model"]
+        categorize = data["search_for"]
 
         exclude_major = data["exclude_major_events"]
         exclude_minor = data["exclude_minor_events"]

--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -202,7 +202,7 @@ class SearchForm(django.forms.Form):
     )
 
     # None autocomplete fields
-    search_model = django.forms.ChoiceField(choices=MODELS, required=False)
+    search_for = django.forms.ChoiceField(choices=MODELS, required=False)
     exclude_major_events = django.forms.BooleanField(required=False)
     exclude_minor_events = django.forms.BooleanField(required=False)
 

--- a/streetcrm/static/js/advanced_search.js
+++ b/streetcrm/static/js/advanced_search.js
@@ -5,7 +5,7 @@ function chooseSearchForm() {
     $("#id_event_search_form").css("display", "none");
 
     // Get the selected model
-    var selectedModel = $("#id_search_model option:selected").val()
+    var selectedModel = $("#id_search_for option:selected").val()
 
     // Find the form for the model
     var formObj = $("#id_" + selectedModel + "_search_form");
@@ -16,7 +16,7 @@ function chooseSearchForm() {
 
 $(document).ready(function () {
     // Set up callbacks.
-    $("#id_search_model").change(chooseSearchForm);
+    $("#id_search_for").change(chooseSearchForm);
 
     // Call chooseSearchForm to get the form to display on page load
     chooseSearchForm();

--- a/streetcrm/static/js/change_advanced_fields.js
+++ b/streetcrm/static/js/change_advanced_fields.js
@@ -8,7 +8,7 @@ performed.
 */
 
 function displayCorrectFields(){
-    if ($("#id_search_model").val() == "event"){
+    if ($("#id_search_for").val() == "event"){
         $(".participant_search_fields").hide();
         $(".action_search_fields").show();
     }
@@ -33,7 +33,7 @@ function clearFilters(){
 
 $(document).ready( function () {
     displayCorrectFields();
-    $('#id_search_model').on("change", function() {
+    $('#id_search_for').on("change", function() {
         displayCorrectFields();
     });
     $('#clear_filters_button').on("click", function(event) {

--- a/streetcrm/templates/admin/search.html
+++ b/streetcrm/templates/admin/search.html
@@ -38,7 +38,7 @@
     <div id="id_search_form">
       <!-- What does the user want to search for, this will dictate the search query -->
       <h4 style="display: inline;">{% trans "Search for " %}</h4>
-      {{ form.search_model }}
+      {{ form.search_for }}
 
       <span class="help-block">
 	{% trans "All fields are optional.  Only fill in the fields which apply to your search." %}


### PR DESCRIPTION
Added the first row to the CSV described in #306. Includes the current date, and then a list of all filters from the advanced search (ignoring null/empty values) or just the search query. Example output is `""Created: 2017-08-01 - Query: search_model = participant, event_tags = swimming,dia_muertos"`