### PR TITLE
Update phone formatting on AJAX response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ django-admin-bootstrapped
 django-phonenumber-field
 django-autocomplete-light<3
 django-watson
+phonenumbers
+psycopg2

--- a/streetcrm/formfields.py
+++ b/streetcrm/formfields.py
@@ -47,7 +47,7 @@ class LocalPhoneNumberField(formfields.PhoneNumberField):
         # Check if phone number returned, and if it's valid. If invalid, check 
         # for the reason to return the specific error message or the default
         if phone_number is None:
-            raise exceptions.ValidationError(self.error_messages['invalid'])
+            return phone_number
         if phone_number and not phone_number.is_valid():
             reason = is_possible_number_with_reason(phone_number)
             raise exceptions.ValidationError(

--- a/streetcrm/formfields.py
+++ b/streetcrm/formfields.py
@@ -16,6 +16,7 @@
 
 import datetime
 import phonenumbers
+from phonenumbers.phonenumberutil import ValidationResult, is_possible_number_with_reason
 
 from django import forms
 from django.core import validators, exceptions
@@ -23,39 +24,36 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 
 from phonenumber_field import formfields
+from phonenumber_field.phonenumber import to_python
 
 from streetcrm import widgets
 
 class LocalPhoneNumberField(formfields.PhoneNumberField):
     """ National representation of phone number """
-
+    default_error_messages = {
+        "invalid": _("Enter a valid phone number."),
+        # If number is invalid but possible, means it failed region check
+        ValidationResult.IS_POSSIBLE: _("Region code is invalid."),
+        ValidationResult.INVALID_COUNTRY_CODE: _("Country code is invalid."),
+        ValidationResult.TOO_SHORT: _("Phone number is too short."),
+        ValidationResult.INVALID_LENGTH: _("Phone number length is invalid."),
+        ValidationResult.TOO_LONG: _("Phone number is too long.")
+    }
     widget = widgets.LocalPhoneNumberWidget
 
     def to_python(self, value, *args, **kwargs):
         """ Convert value from National US phone number to international """
-        if value in validators.EMPTY_VALUES:
-            value = None
-        else:
-            # Parse the value
-            try:
-                if value.startswith("+"):
-                    value = phonenumbers.parse(value)
-                else:
-                    value = phonenumbers.parse(value, "US")
-            except phonenumbers.phonenumberutil.NumberParseException:
-                value = phonenumbers.PhoneNumber(raw_input=value)
-
-            # Produce international format without formatting.
-            value = "+{country_code}{national_number}".format(
-                country_code=value.country_code,
-                national_number=value.national_number
+        phone_number = to_python(value)
+        # Check if phone number returned, and if it's valid. If invalid, check 
+        # for the reason to return the specific error message or the default
+        if phone_number is None:
+            raise exceptions.ValidationError(self.error_messages['invalid'])
+        if phone_number and not phone_number.is_valid():
+            reason = is_possible_number_with_reason(phone_number)
+            raise exceptions.ValidationError(
+                self.error_messages.get(reason, self.error_messages['invalid'])
             )
-
-        try: return super(LocalPhoneNumberField, self).to_python(
-            value, *args, **kwargs
-        )
-        except:
-            raise exceptions.ValidationError("Please enter a phone number in the format (xxx) xxx-xxxx", code="invalid")
+        return phone_number
 
 class TwelveHourTimeField(forms.TimeField):
     widget = widgets.TwelveHourTimeWidget

--- a/streetcrm/settings.py
+++ b/streetcrm/settings.py
@@ -179,3 +179,6 @@ ADMIN_ORDERING = (
 # This setting controls how many participants/contacts can be linked at any
 # given time to an institution.
 CONTACT_LIMIT = config["contact"]["limit"]
+
+PHONENUMBER_DEFAULT_REGION = 'US'
+PHONENUMBER_DEFAULT_FORMAT = 'E164'

--- a/streetcrm/static/js/inline_ajax.js
+++ b/streetcrm/static/js/inline_ajax.js
@@ -731,6 +731,7 @@ function putInlinedModel(form_data, model_id, row, cell) {
             cell.children(".static").children("span.static-span").text(cell.find("input").val());
             createProfileLink(updated_model, cell);
             row.data("model", updated_model);
+            fillTableRow(row);
             cell.find(".static").show();
             cell.find(".editable").hide();
         },


### PR DESCRIPTION
Fixes #187 by updating the row with the JSON response data, including the re-formatted phone number.

This doesn't fix delivering the correct error message though. It looks like the issue is in the [exception handling for the phone number input field](https://github.com/OpenTechStrategies/streetcrm/blob/master/streetcrm/formfields.py#L54). It catches any `NumberParseException` (which it sounds like we want), changes that to the raw value, and then passes it to the generic `PhoneNumberField` which gives the standard error message.

Do we want to throw the exception from `phonenumbers` if a phone number fails the parsing rather than passing it to the `PhoneNumberField`? And if that makes sense, should we use [their existing error messages](https://github.com/daviddrysdale/python-phonenumbers/blob/dev/python/phonenumbers/phonenumberutil.py#L3137)? They seem comprehensive, but it might be worth condensing some of them (i.e. there are two versions of phone numbers being too short that could just return "Phone number is too short").

Let me know what makes the most sense and I can either add it to this PR or make a separate one