### PR TITLE
Alphabetizing event search results, displaying basic, template tag for section

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ django-admin-bootstrapped
 django-phonenumber-field
 django-autocomplete-light<3
 django-watson
+phonenumbers
+psycopg2

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -252,7 +252,7 @@ class STREETCRMAdminSite(admin.AdminSite):
             request,
             self.search_template,
             {
-                "search_results": {"results": results},
+                "search_results": results,
                 "form": form,
                 "query": search_query,
             }
@@ -275,18 +275,15 @@ class STREETCRMAdminSite(admin.AdminSite):
             result_count = participant_count
         
         if categorize == form.EVENT:
-            prep_event_count = len(self._nested_search(
-                results,
-                lambda o: isinstance(o, models.Event) and o.is_prep
-            ))
-            major_event_count = len(self._nested_search(
-                results,
-                lambda o: isinstance(o, models.Event) and not o.is_prep
-            ))
-            result_count = len(self._nested_search(
-                results,
-                lambda o: isinstance(o, models.Event)
-            ))
+            prep_event_count = len([
+                o for o in results if isinstance(o, models.Event) and o.is_prep
+            ])
+            major_event_count = len([
+                o for o in results if isinstance(o, models.Event) and not o.is_prep
+            ])
+            result_count = len([
+                o for o in results if isinstance(o, models.Event)
+            ])
         elif categorize == form.INSTITUTION:
             institution_count = len(self._nested_search(
                 results,
@@ -540,16 +537,14 @@ class STREETCRMAdminSite(admin.AdminSite):
                 (_("No Event"), no_event),
             ))
 
-        # Remove any without participants
-        # results = self._remove_empty_values(results)
-
         if (len(results) == 1):
             results = results[None]
+            results = sorted(results, key=lambda object: object.name)
         else:
-            print("DEBUG: length of results was greater than 1")
-            print("DEBUG: we're looking at action results")
-            
-        results = sorted(results, key=lambda object: object.name)
+            results = sorted(
+                list(results[_("Major")].keys()) + list(results[_("Minor")].keys()), 
+                key=lambda object: object.name
+            )
         
         # If this is not an export, get counts:
         if not export:

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -529,7 +529,10 @@ class STREETCRMAdminSite(admin.AdminSite):
 
         if categorize != form.EVENT:
             results = results[None]
-        results = sorted(results, key=lambda object: object.name)
+        results = sorted(
+            [r for r in results if r is not None],
+            key=lambda object: object.name
+        )
         
         # If this is not an export, get counts:
         if not export:

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -263,7 +263,7 @@ class STREETCRMAdminSite(admin.AdminSite):
         Returns counts of different result types for advanced search.
         """
         data = form.get_processed_data()
-        categorize = data["search_model"]
+        categorize = data["search_for"]
 
         major_event_count = None
         prep_event_count = None
@@ -305,7 +305,7 @@ class STREETCRMAdminSite(admin.AdminSite):
         This provides advanced searching options
         """
         data = form.get_processed_data()
-        categorize = data["search_model"]
+        categorize = data["search_for"]
 
         exclude_major = data["exclude_major_events"]
         exclude_minor = data["exclude_minor_events"]
@@ -546,8 +546,24 @@ class STREETCRMAdminSite(admin.AdminSite):
                                "result_count": count_set['result_count']
             }
         else:
+            search_params = []
+            for key, value in data.items():
+                if isinstance(value, datetime):
+                    search_params.append('{} = {}'.format(key, value.strftime('%Y-%m-%d')))
+                elif isinstance(value, str) and len(value):
+                    search_params.append('{} = {}'.format(key, value))
+                elif isinstance(value, bool) and value:
+                    search_params.append(key)
+                elif hasattr(value, '__iter__') and len(value):
+                    search_params.append('{} = {}'.format(key, ','.join([str(v) for v in value])))
+                elif hasattr(value, 'pk'):
+                    search_params.append('{} = {}'.format(key, str(value)))
+
+            search_header = ', '.join(search_params)
+
             results_package = {"form": form,
                                "search_results": results,
+                               "search_header": search_header,
                                "event_results": event_list
             }
             
@@ -601,8 +617,10 @@ class STREETCRMAdminSite(admin.AdminSite):
             except KeyError:
                 # If the results are actions:
                 search_results = results_package["event_results"]
+            search_header = results_package['search_header']
         else:
             search_results = STREETCRMAdminSite.basic_search_do(STREETCRMAdminSite, request, search_query)
+            search_header = search_query
 
         # Special columns include: institution_id, organizer_id, and
         # major_action_id.  These should all display the name of the
@@ -632,15 +650,18 @@ class STREETCRMAdminSite(admin.AdminSite):
         
         last_header=[]
         header=[]
+        
+        search_title = 'Exported on: {} - Search terms: {}'.format(
+            filetime.strftime('%Y-%m-%d'), search_header
+        )
+        writer.writerow([search_title])
+        
         for result in search_results:
             if result is None:
                 continue
             # Convert the result object (participant, institution, etc.)
             # to a row.
-            #
-            # add a title row
-            #
-            
+
             # intended behavior: each model type is grouped together
             # under one header row.  This header row matches the columns
             # of data that are displayed.  Eventually, this will be
@@ -1014,9 +1035,12 @@ class EventAdmin(mixins.AdminArchiveMixin, AjaxyInlineAdmin):
              "form_name": "institution",
              "input_type": "fkey_autocomplete_name",
              "autocomplete_uri": "/autocomplete/InstitutionAutocomplete/"},
-            {"descriptive_name": "Attendee's Phone Number",
+            {"descriptive_name": "Phone Number",
              "form_name": "primary_phone",
              "input_type": "text"},
+            {"descriptive_name": "Email",
+             "form_name": "email",
+             "input_type": "text"}
          ],
     }
 

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -519,32 +519,17 @@ class STREETCRMAdminSite(admin.AdminSite):
                 results = results.intersection(leader_set)
             results = {None: results}
         if categorize == form.EVENT:
-            # Separate the events up (yes i know we merged them above).
-            major = {}
-            minor = {}
-            no_event = []
-            for event, participants in event_participants.items():
-                if event is None:
-                    no_event += participants
-                elif event.is_prep:
-                    minor[event] = participants
-                else:
-                    major[event] = participants
+            if data.get("participant"):
+                results = []
+                for event, participants in event_participants.items():
+                    if participants.count():
+                        results.append(event)
+            else:
+                results = [e for e, p in event_participants.items() if e is not None]
 
-            results = collections.OrderedDict((
-                (_("Major"), major),
-                (_("Minor"), minor),
-                (_("No Event"), no_event),
-            ))
-
-        if (len(results) == 1):
+        if categorize != form.EVENT:
             results = results[None]
-            results = sorted(results, key=lambda object: object.name)
-        else:
-            results = sorted(
-                list(results[_("Major")].keys()) + list(results[_("Minor")].keys()), 
-                key=lambda object: object.name
-            )
+        results = sorted(results, key=lambda object: object.name)
         
         # If this is not an export, get counts:
         if not export:

--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -202,7 +202,7 @@ class SearchForm(django.forms.Form):
     )
 
     # None autocomplete fields
-    search_model = django.forms.ChoiceField(choices=MODELS, required=False)
+    search_for = django.forms.ChoiceField(choices=MODELS, required=False)
     exclude_major_events = django.forms.BooleanField(required=False)
     exclude_minor_events = django.forms.BooleanField(required=False)
 

--- a/streetcrm/migrations/0064_auto_20170801_2008.py
+++ b/streetcrm/migrations/0064_auto_20170801_2008.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('streetcrm', '0063_auto_20170404_1212'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='participant',
+            options={'ordering': ['name']},
+        ),
+    ]

--- a/streetcrm/models.py
+++ b/streetcrm/models.py
@@ -243,6 +243,9 @@ class Institution(ArchiveAbstract, SerializeableMixin):
 
 class Participant(ArchiveAbstract, SerializeableMixin):
     """ Representation of a person who can participate in a Event """
+    class Meta:
+        ordering = ['name']
+
     name = models.CharField(max_length=255, verbose_name="Participant Name")
     primary_phone = modelfields.PhoneNumberField(null=True, blank=True,
                                                  verbose_name="Participant Phone")

--- a/streetcrm/settings.py
+++ b/streetcrm/settings.py
@@ -179,3 +179,6 @@ ADMIN_ORDERING = (
 # This setting controls how many participants/contacts can be linked at any
 # given time to an institution.
 CONTACT_LIMIT = config["contact"]["limit"]
+
+PHONENUMBER_DEFAULT_REGION = 'US'
+PHONENUMBER_DEFAULT_FORMAT = 'E164'

--- a/streetcrm/static/js/advanced_search.js
+++ b/streetcrm/static/js/advanced_search.js
@@ -5,7 +5,7 @@ function chooseSearchForm() {
     $("#id_event_search_form").css("display", "none");
 
     // Get the selected model
-    var selectedModel = $("#id_search_model option:selected").val()
+    var selectedModel = $("#id_search_for option:selected").val()
 
     // Find the form for the model
     var formObj = $("#id_" + selectedModel + "_search_form");
@@ -16,7 +16,7 @@ function chooseSearchForm() {
 
 $(document).ready(function () {
     // Set up callbacks.
-    $("#id_search_model").change(chooseSearchForm);
+    $("#id_search_for").change(chooseSearchForm);
 
     // Call chooseSearchForm to get the form to display on page load
     chooseSearchForm();

--- a/streetcrm/static/js/change_advanced_fields.js
+++ b/streetcrm/static/js/change_advanced_fields.js
@@ -8,7 +8,7 @@ performed.
 */
 
 function displayCorrectFields(){
-    if ($("#id_search_model").val() == "event"){
+    if ($("#id_search_for").val() == "event"){
         $(".participant_search_fields").hide();
         $(".action_search_fields").show();
     }
@@ -33,7 +33,7 @@ function clearFilters(){
 
 $(document).ready( function () {
     displayCorrectFields();
-    $('#id_search_model').on("change", function() {
+    $('#id_search_for').on("change", function() {
         displayCorrectFields();
     });
     $('#clear_filters_button').on("click", function(event) {

--- a/streetcrm/static/js/inline_ajax.js
+++ b/streetcrm/static/js/inline_ajax.js
@@ -731,6 +731,7 @@ function putInlinedModel(form_data, model_id, row, cell) {
             cell.children(".static").children("span.static-span").text(cell.find("input").val());
             createProfileLink(updated_model, cell);
             row.data("model", updated_model);
+            fillTableRow(row);
             cell.find(".static").show();
             cell.find(".editable").hide();
         },

--- a/streetcrm/templates/admin/includes/search_result_block.html
+++ b/streetcrm/templates/admin/includes/search_result_block.html
@@ -1,11 +1,12 @@
 {% load i18n %}
+{% load search_result_tags %}
 
 {% with helptext="Sorry, there were no results for this search.  If you're not sure how to spell someone's full name, try searching on just part of it.  For example, to find Martin Gonzalez, you could search by M* G*." %}
 
 <h1>{% trans "Results" %}</h1>
 <ul>
 
-  {% if not advanced and not search_results.results %}
+  {% if not advanced and not search_results %}
   {{helptext}}
   
   {% elif advanced and search_results and not result_count %}
@@ -21,10 +22,9 @@
     we're just showing actions without attendees, now.
     {% endcomment %}
     
-    {% if section != "No Event" %}
-    <li><a href="{{ object.admin_change_url }}">{{ object }}</a>
-    {% if section and section != "results" %} ({{ section }}) {% endif %} </li>
-    {% endif %}
+    <li>
+      <a href="{{ object.admin_change_url }}">{{ object }}</a> {% section_display object %}
+    </li>
   </ul>
   {% endfor %}
 </ul>
@@ -32,4 +32,3 @@
 {% endif %}
 
 {% endwith %}
-

--- a/streetcrm/templates/admin/search.html
+++ b/streetcrm/templates/admin/search.html
@@ -38,7 +38,7 @@
     <div id="id_search_form">
       <!-- What does the user want to search for, this will dictate the search query -->
       <h4 style="display: inline;">{% trans "Search for " %}</h4>
-      {{ form.search_model }}
+      {{ form.search_for }}
 
       <span class="help-block">
 	{% trans "All fields are optional.  Only fill in the fields which apply to your search." %}

--- a/streetcrm/templatetags/search_result_tags.py
+++ b/streetcrm/templatetags/search_result_tags.py
@@ -1,0 +1,26 @@
+# StreetCRM is a list of contacts with a history of their event attendance
+# Copyright (C) 2015  Local Initiatives Support Corporation (LISC)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.template import Library
+
+
+register = Library()
+
+@register.simple_tag
+def section_display(obj):
+    if hasattr(obj, 'is_prep'):
+        return '(MINOR)' if obj.is_prep else '(MAJOR)'
+    return ''


### PR DESCRIPTION
This has the advanced search results for events as well as participants working, gets rid of the `results` dict and key to display basic search results, and adds a template tag for loading the event type.

Wanted to get some thoughts on whether updates enough for now (given the time frame) or whether it's worth cleaning up the the `OrderedDict` objects in earlier methods that aren't necessary now. I think it would be manageable to remove some of the earlier reference without doing a full refactor, but I could be underestimating it

Also, is the template tag is too much to just handle displaying the section on events? I couldn't think of another way that didn't overcomplicate the search functions