### PR TITLE
Adding email to action sign-in sheet

### DIFF
--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -1023,6 +1023,9 @@ class EventAdmin(mixins.AdminArchiveMixin, AjaxyInlineAdmin):
             {"descriptive_name": "Attendee's Phone Number",
              "form_name": "primary_phone",
              "input_type": "text"},
+            {"descriptive_name": "Attendee's Email",
+             "form_name": "email",
+             "input_type": "text"}
          ],
     }
 

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -1020,10 +1020,10 @@ class EventAdmin(mixins.AdminArchiveMixin, AjaxyInlineAdmin):
              "form_name": "institution",
              "input_type": "fkey_autocomplete_name",
              "autocomplete_uri": "/autocomplete/InstitutionAutocomplete/"},
-            {"descriptive_name": "Attendee's Phone Number",
+            {"descriptive_name": "Phone Number",
              "form_name": "primary_phone",
              "input_type": "text"},
-            {"descriptive_name": "Attendee's Email",
+            {"descriptive_name": "Email",
              "form_name": "email",
              "input_type": "text"}
          ],


### PR DESCRIPTION
Addresses #302. After testing it out, it actually looks like email fits without expanding the form width, but the column headers are a little cramped. Given the title of the form is Attendees, is it alright to change the column names to just "Phone Number" and "Email"?

<img width="897" alt="screen shot 2017-08-05 at 3 48 01 pm" src="https://user-images.githubusercontent.com/8291663/28998634-e49a384a-79f5-11e7-8aff-a743c5bd7b0b.png">
<img width="873" alt="screen shot 2017-08-05 at 3 48 29 pm" src="https://user-images.githubusercontent.com/8291663/28998635-e7a49d28-79f5-11e7-9d27-3b15885d1e90.png">
 