### PR TITLE
Add overflow scroll and message to autocomplete

### DIFF
--- a/streetcrm/static/css/streetcrm.css.tmpl
+++ b/streetcrm/static/css/streetcrm.css.tmpl
@@ -619,3 +619,15 @@ h2#stages-header:hover {
 .pull-right {
     float: right;
 }
+
+.ui-autocomplete {
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.scroll-indication {
+  font-style: italic;
+  padding: 3px 1em 3px .4em;
+  min-height: 0;
+}

--- a/streetcrm/static/js/inline_ajax.js
+++ b/streetcrm/static/js/inline_ajax.js
@@ -28,6 +28,27 @@ Sounds confusing?  It's not too hard to use.  Take a look:
   var my_url = url_formatter({"<froob_id>": 35});
 */
 
+/* Extends the autocomplete widget to add an indication that the user should
+   scroll to see more results if a longer list, and to not treat this message
+   as another result option. */
+$.widget( "ui.autocomplete", $.ui.autocomplete, {
+  options: {items: "> *:not(.scroll-indication)"},
+  _create: function() {
+    $.ui.menu.prototype.options.items = this.options.items;
+    this._super();
+  },
+  _renderMenu: function(ul, items) {
+    var that = this;
+		$.each( items, function( index, item ) {
+			that._renderItemData( ul, item );
+		});
+    var count = $.map(items, function() { return 1; }).length;
+    if (count >= 4 && this.options.items === "> *:not(.scroll-indication)") {
+      ul.prepend("<li class='scroll-indication'>Scroll for more results</li>");
+    }
+  }
+});
+
 function gummyStringFormatter(string_pattern) {
     return function(replace_map) {
         var new_str = "";


### PR DESCRIPTION
Should address most of #303 by adding a max height with a scrolling overflow to autocomplete elements as well as a message to scroll for more results if they have 4 or more items. Had to go deeper into prototypal inheritance than I would have liked here to make sure that the scroll message wasn't treated as an autocomplete result.

<img width="765" alt="screen shot 2017-08-26 at 12 02 07 pm" src="https://user-images.githubusercontent.com/8291663/29743418-6123358a-8a57-11e7-8113-1fd3b1cfaa78.png">
