### PR TITLE
Remove old pop-up link click handlers

### DIFF
--- a/streetcrm/static/js/inline_ajax.js
+++ b/streetcrm/static/js/inline_ajax.js
@@ -376,6 +376,7 @@ function createProfileLink(model, cell) {
   var profileLink = cell.children(".static").children("a.profile-link");
   if (cell.data("form-name") == "name") {
     if (model.id != undefined) {
+      profileLink.unbind("click");
       profileLink.on("click", function() { createPopup(model.id) });
       profileLink.css("display", "inline");
     }


### PR DESCRIPTION
Fixes #321. Pop-up data was getting duplicated because obsolete click handlers were not being removed between updates, so that the event would keep getting added rather than replaced. Unbinding each time it's assigned to fix. Tested on Chrome and Firefox