### PR TITLE
WIP: Initial attempt at upgrade to Django 1.11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -321,3 +321,16 @@ post-rename.  After that, migrations should all work as expected and you can jus
 
 as usual.
 
+Upgrading from Django 1.8
+------------------------
+
+There are a few additional steps for upgrading an existing instance from Django 1.8.
+
+* First you'll need to run `pip install -U -r requirements.txt` to upgrade your virtual
+environment.
+* There are additional migrations in between Django 1.8 and 1.11, so you'll need to run
+`python manage.py migrate`.
+
+Additionally, there are a few items to keep in mind:
+
+* Edit and add buttons are changed on foreign key fields (for fields like Organizer on Events).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django<1.12
 configobj
-django-admin-bootstrapped
+git+https://github.com/ZeroCater/django-admin-bootstrapped.git@13a0441b553fee6364001e1d1d5960614938ebb3#egg=django_admin_bootstrapped
 django-phonenumber-field
 django-autocomplete-light<3
 django-watson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django<1.9
+django<1.12
 configobj
 django-admin-bootstrapped
 django-phonenumber-field

--- a/streetcrm/__init__.py
+++ b/streetcrm/__init__.py
@@ -13,6 +13,3 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# import the signals (needs to happen to register them)self.
-from streetcrm import signals

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -723,7 +723,8 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
                      "participant_zipcode_address")
     list_filter = (admin_filters.ArchivedFilter,)
     list_display = ("name", "US_primary_phone", "institution", "participant_street_address", "participant_city_address",)
-    readonly_fields = ("action_history", "event_history_name")
+    # HAD TO REMOVE event_history_name DUE TO ISSUES
+    readonly_fields = ("action_history",)
     fieldsets = (
         (None, {
             "fields": ("name", "primary_phone",
@@ -770,9 +771,7 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
         """ HTML history of the events attended by the participant """
         template_name = "admin/includes/event_history.html"
         action_history_template = loader.get_template(template_name)
-        context = template.Context({
-            "events": obj.events,
-        })
+        context = {"events": obj.events}
         return action_history_template.render(context)
 
     # To prevent django from distorting how the event_history method looks tell

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -723,7 +723,7 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
                      "participant_zipcode_address")
     list_filter = (admin_filters.ArchivedFilter,)
     list_display = ("name", "US_primary_phone", "institution", "participant_street_address", "participant_city_address",)
-    # HAD TO REMOVE event_history_name DUE TO ISSUES
+    # TODO: Fix event_history_name, re-add to readonly_fields
     readonly_fields = ("action_history",)
     fieldsets = (
         (None, {

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -723,7 +723,6 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
                      "participant_zipcode_address")
     list_filter = (admin_filters.ArchivedFilter,)
     list_display = ("name", "US_primary_phone", "institution", "participant_street_address", "participant_city_address",)
-    # TODO: Fix event_history_name, re-add to readonly_fields
     readonly_fields = ("action_history",)
     fieldsets = (
         (None, {
@@ -760,13 +759,6 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
     form = st_forms.ParticipantForm
     actions = None
 
-    @property
-    def event_history_name(self, obj):
-        """ Name of event history fieldset """
-        return "Actions that {name} attended".format(
-            name=obj.name
-        )
-
     def action_history(self, obj):
         """ HTML history of the events attended by the participant """
         template_name = "admin/includes/event_history.html"
@@ -777,6 +769,7 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
     # To prevent django from distorting how the event_history method looks tell
     # it to allow HTML using the allow_tags method attribute.
     action_history.allow_tags = True
+    action_history.short_description = "Actions this participant attended"
 
     def US_primary_phone(self, obj):
         if obj.primary_phone is None or obj.primary_phone == "":

--- a/streetcrm/apps.py
+++ b/streetcrm/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class STREETCRMAppConfig(AppConfig):
+    name = 'streetcrm'
+
+    def ready(self):
+        import streetcrm.signals

--- a/streetcrm/autocomplete_light_registry.py
+++ b/streetcrm/autocomplete_light_registry.py
@@ -1,4 +1,4 @@
-import autocomplete_light
+import autocomplete_light.shortcuts as autocomplete_light
 from django.db.models import Q
 
 from streetcrm import models

--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -57,7 +57,6 @@ class TagAdminForm(django.forms.ModelForm):
             "name": django.forms.TextInput(
                 attrs={"size": models.Tag.get_field("name").max_length}
             ),
-            "group": widgets.ForeignKeyRadioWidget(),
         }
 
 class AutoCompleteModelForm(forms.ModelForm):

--- a/streetcrm/mixins.py
+++ b/streetcrm/mixins.py
@@ -18,7 +18,7 @@ from django import http
 from django.db import transaction
 from django.contrib import messages
 from django.core import urlresolvers
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response
 from django.forms.models import modelform_factory
@@ -45,9 +45,9 @@ class SignInSheetAdminMixin:
 
         # Define the sign in sheet URL
         sheet_view = self.admin_site.admin_view(self.sheet_view)
-        sheet_url = patterns("",
+        sheet_url = [
             url(r"sign-in-sheet/$", sheet_view, name="sign-in-sheet"),
-        )
+        ]
 
         return sheet_url + urls
 

--- a/streetcrm/models.py
+++ b/streetcrm/models.py
@@ -136,8 +136,6 @@ class InspectMixin:
     @classmethod
     def get_field(cls, name):
         """ Gets a field by it's name """
-        # Updated https://docs.djangoproject.com/en/1.11/ref/models/meta/#retrieving-a-single-field-instance-of-a-model-by-name
-        # return cls._meta.get_field_by_name(name)[0]
         return cls._meta.get_field(name)
 
 class StreetcrmModel(models.Model):

--- a/streetcrm/models.py
+++ b/streetcrm/models.py
@@ -136,7 +136,9 @@ class InspectMixin:
     @classmethod
     def get_field(cls, name):
         """ Gets a field by it's name """
-        return cls._meta.get_field_by_name(name)[0]
+        # Updated https://docs.djangoproject.com/en/1.11/ref/models/meta/#retrieving-a-single-field-instance-of-a-model-by-name
+        # return cls._meta.get_field_by_name(name)[0]
+        return cls._meta.get_field(name)
 
 class StreetcrmModel(models.Model):
     """

--- a/streetcrm/settings.py
+++ b/streetcrm/settings.py
@@ -73,30 +73,35 @@ ORG_NAME = config["general"].get("org_name", None)
 
 # This should never be True in production.
 DEBUG = config["general"]["debug"]
-TEMPLATE_DEBUG = DEBUG
 
 # List of accepted hosts the site runs on.
 ALLOWED_HOSTS = config["general"]["allowed_hosts"]
 
 
-# Application definition
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, "streetcrm", "templates"),
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.template.context_processors.debug",
-    "django.template.context_processors.i18n",
-    "django.template.context_processors.media",
-    "django.template.context_processors.static",
-    "django.template.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "streetcrm.context_processors.search_header",
-    "streetcrm.context_processors.for_logo",
-    "streetcrm.context_processors.check_archive_permission",
-    "streetcrm.context_processors.custom_theme",
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(BASE_DIR, "streetcrm", "templates")
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "streetcrm.context_processors.search_header",
+                "streetcrm.context_processors.for_logo",
+                "streetcrm.context_processors.check_archive_permission",
+                "streetcrm.context_processors.custom_theme",
+            ],
+        }
+    },
+]
 
 
 INSTALLED_APPS = (
@@ -108,7 +113,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'streetcrm',
+    'streetcrm.apps.STREETCRMAppConfig',
     'watson',
 )
 

--- a/streetcrm/templates/admin/leader_stage_inline_tabular.html
+++ b/streetcrm/templates/admin/leader_stage_inline_tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static admin_modify %}{% load cycle from future %}
+{% load i18n admin_static admin_modify %}
 <div class="inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}

--- a/streetcrm/urls.py
+++ b/streetcrm/urls.py
@@ -17,11 +17,11 @@
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from streetcrm import views, admin
 
-urlpatterns = patterns("",
+urlpatterns = [
     # Autocomplete app URLs
     url(r"^autocomplete/", include("autocomplete_light.urls")),
 
@@ -29,31 +29,31 @@ urlpatterns = patterns("",
     url(r"^", admin.site.urls),
 
     # API URLs
-    url(r"^api/", include(patterns("",
-        url(r"^participants/", include(patterns("",
+    url(r"^api/", include([
+        url(r"^participants/", include([
             url(r"^$", views.CreateParticipantAPI.as_view(), name="api-create-participants"),
             url(r"^(?P<pk>\w+)/$", views.ParticipantAPI.as_view(), name="api-participants"),
             url(r"^([\w-]+)/$", views.ParticipantAPI.as_view(), name="api-participants"),
             url(r"^contact/(?P<pk>\w+)/$", views.ContactParticipantAPI.as_view(), name="api-participants"),
-        ))),
+        ])),
         url(r"^contacts/", views.CreateContactAPI.as_view(), name="api-create-contacts"),
-        url(r"^events/(?P<pk>\w+)/", include(patterns("",
+        url(r"^events/(?P<pk>\w+)/", include([
             url(r"^participants/$", views.EventParticipantsAPI.as_view(), name="api-event-participants"),
             url(r"^available-participants/$", views.EventAvailableAPI.as_view(), name="api-event-available"),
             url(r"participants/(?P<participant_id>\w+)/$", views.EventLinking.as_view(), name="api-event-linking"),
-        ))),
-        url(r"^institutions/(?P<pk>\w+)/", include(patterns("",
+        ])),
+        url(r"^institutions/(?P<pk>\w+)/", include([
             url(r"^contacts/$", views.InstitutionContactsAPI.as_view(), name="api-institution-contacts"),
             url(r"contacts/(?P<participant_id>\w+)/$", views.ContactLinking.as_view(), name="api-contact-linking"),
-        ))),
+        ])),
 
         # This section covers endpoints for the current authenticated user
-        url(r"^current/", include(patterns("",
+        url(r"^current/", include([
             url(r"^available-tags/$", views.AvailableTagsAPI.as_view(), name="api-tags-available"),
-        ))),
-    ))),
+        ])),
+    ])),
     #autocomplete_light urls
     url(r'^autocomplete/', include('autocomplete_light.urls')
     ),
 
-)
+]

--- a/streetcrm/widgets.py
+++ b/streetcrm/widgets.py
@@ -36,17 +36,8 @@ class LocalPhoneNumberWidget(forms.TextInput):
             name, value, *args, **kwargs
         )
 
-# class ForeignKeyRadioRenderer(widgets.RadioFieldRenderer):
 
-#     def __init__(self, *args, **kwargs):
-#         super(ForeignKeyRadioRenderer, self).__init__(*args, **kwargs)
-#         # Remove the None value which is "---------" (it's always the first one)
-#         self.choices = self.choices[1:]
-
-
-# class ForeignKeyRadioWidget(forms.RadioSelect):
-#     """ Radio widget that provides radio buttons """
-#     renderer = ForeignKeyRadioRenderer
+# TODO: Replicate removing None value with templates
 class ForeignKeyRadioWidget(forms.RadioSelect):
     pass
 

--- a/streetcrm/widgets.py
+++ b/streetcrm/widgets.py
@@ -37,11 +37,6 @@ class LocalPhoneNumberWidget(forms.TextInput):
         )
 
 
-# TODO: Replicate removing None value with templates
-class ForeignKeyRadioWidget(forms.RadioSelect):
-    pass
-
-
 class TwelveHourTimeWidget(forms.MultiWidget):
     """ 12 Hour time widget that gives back a datetime.time object """
 

--- a/streetcrm/widgets.py
+++ b/streetcrm/widgets.py
@@ -36,17 +36,20 @@ class LocalPhoneNumberWidget(forms.TextInput):
             name, value, *args, **kwargs
         )
 
-class ForeignKeyRadioRenderer(widgets.RadioFieldRenderer):
+# class ForeignKeyRadioRenderer(widgets.RadioFieldRenderer):
 
-    def __init__(self, *args, **kwargs):
-        super(ForeignKeyRadioRenderer, self).__init__(*args, **kwargs)
-        # Remove the None value which is "---------" (it's always the first one)
-        self.choices = self.choices[1:]
+#     def __init__(self, *args, **kwargs):
+#         super(ForeignKeyRadioRenderer, self).__init__(*args, **kwargs)
+#         # Remove the None value which is "---------" (it's always the first one)
+#         self.choices = self.choices[1:]
 
 
+# class ForeignKeyRadioWidget(forms.RadioSelect):
+#     """ Radio widget that provides radio buttons """
+#     renderer = ForeignKeyRadioRenderer
 class ForeignKeyRadioWidget(forms.RadioSelect):
-    """ Radio widget that provides radio buttons """
-    renderer = ForeignKeyRadioRenderer
+    pass
+
 
 class TwelveHourTimeWidget(forms.MultiWidget):
     """ 12 Hour time widget that gives back a datetime.time object """


### PR DESCRIPTION
It seemed like the easiest way to research the upgrade for #326 would be to try it out and see what happens. Overall, it looks pretty doable, and this runs locally with a few caveats. I also haven't done too much testing other than clicking around and making sure templates render.

Most of the changes are relating to configuration updates and end up about the same, but there are a few that I want to flag here:

* I'm not entirely sure why, but `readonly_fields` in the admin doesn't like the `event_history_name` property method, so I removed it for now
* The API around `get_field_by_name` seems to have changed, which, if I have it implemented correctly, makes things a lot simpler
* The biggest change that I haven't updated from what I've seen so far is on `ForeignKeyRadioWidget`. It shouldn't be difficult, but Django is moving from widgets to smaller templates for form components, so we would just need to create a new template with the described behavior

There are a lot of other changes in here, and there are likely things I haven't found yet, but this seems like a way to start the conversation