### PR TITLE
Add simple reporting features

### DIFF
--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -355,7 +355,7 @@ class STREETCRMAdminSite(admin.AdminSite):
                 ).order_by(Lower("name"))
 
             if data.get("event_count"):
-                results = results.filter(event_count=data.get("event_count"))
+                results = results.filter(event_count__gte=data.get("event_count"))
         elif categorize == form.EVENT:
             if isinstance(data["participant"], str):
                 query_dict["participants__name__icontains"] = data["participant"]
@@ -478,7 +478,8 @@ class STREETCRMAdminSite(admin.AdminSite):
             {"column": "participant_street_address", "heading":
             "Address"},
             {"column": "institution_id", "heading": "Institution"},
-            {"column": "leadership", "heading": "Leadership level"}
+            {"column": "leadership", "heading": "Leadership level"},
+            {"column": "event_count", "heading": "Count attendances"}
         ]
         institution_header=[
             {"column": "id", "heading": "ID"},

--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -491,7 +491,7 @@ class STREETCRMAdminSite(admin.AdminSite):
             "Address"},
             {"column": "institution_id", "heading": "Institution"},
             {"column": "leadership", "heading": "Leadership level"},
-            {"column": "event_count", "heading": "Count attendances"}
+            {"column": "event_count", "heading": "Number of attendances"}
         ]
         institution_header=[
             {"column": "id", "heading": "ID"},
@@ -508,7 +508,7 @@ class STREETCRMAdminSite(admin.AdminSite):
             {"column": "location", "heading": "Location"},
             {"column": "narrative", "heading": "Narrative"},
             {"column": "major_action_id", "heading": "Major action"},
-            {"column": "attendance_count", "heading": "Count attendances"}
+            {"column": "attendance_count", "heading": "Count attendees"}
         ]
         
         last_header=[]

--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -196,6 +196,11 @@ class SearchForm(django.forms.Form):
         required=False
     )
 
+    event_count = django.forms.IntegerField(
+        required=False,
+        min_value=0
+    )
+
     institution_tags = forms.ModelMultipleChoiceField(
         "ASTagAutocomplete",
         required=False

--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -198,7 +198,7 @@ class SearchForm(django.forms.Form):
 
     event_count = django.forms.IntegerField(
         required=False,
-        min_value=0
+        min_value=1
     )
 
     institution_tags = forms.ModelMultipleChoiceField(

--- a/streetcrm/templates/admin/search.html
+++ b/streetcrm/templates/admin/search.html
@@ -76,6 +76,10 @@
           <td>{% trans "Any action tagged:" %}</td>
           <td>{{ form.event_tags }}</td>
         </tr>
+        <tr class="participant_search_fields">
+          <td>{% trans "Attended this many actions:" %}</td>
+          <td>{{ form.event_count }}</td>
+        </tr>
         <tr class="action_search_fields">
           <td>{% trans "Attended by: " %}</td>
           <td>{{ form.participant }} </td>
@@ -135,7 +139,10 @@
       <li>{% trans "Prep Actions:" %} {{ prep_event_count }}</li>
       {% endif %}
       {% if participant_count %}
-      <li>{% trans "Unique Participants:" %} {{ participant_count }}</li>
+      <li>{% trans "Participants:" %} {{ participant_count }}</li>
+      {% endif %}
+      {% if unique_participant_count %}
+      <li>{% trans "Unique Participants:" %} {{ unique_participant_count }}</li>
       {% endif %}
     </ul>
     {% endblock %}

--- a/streetcrm/templates/admin/search.html
+++ b/streetcrm/templates/admin/search.html
@@ -77,7 +77,7 @@
           <td>{{ form.event_tags }}</td>
         </tr>
         <tr class="participant_search_fields">
-          <td>{% trans "Attended this many actions:" %}</td>
+          <td>{% trans "Attended at least this many actions:" %}</td>
           <td>{{ form.event_count }}</td>
         </tr>
         <tr class="action_search_fields">


### PR DESCRIPTION
Closes #332. Adds a count of "Unique Participants" to event results (changes previous "Unique" header to just "Participants"), adds a count of attendances per action to the CSV export, and allows for filtering on exact number of events attended in the filtered time period.

My main question is if the attendance count filter should be "attended at least this many" actions, or whether we should some way of either searching for an exact count or a range