### PR TITLE
Update When kwarg order to match docs

### DIFF
--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -354,7 +354,7 @@ class STREETCRMAdminSite(admin.AdminSite):
                     event_count_dict[event_query] = query_dict[event_query]
             if event_count_dict:
                 event_count = Count(Case(
-                    When(**event_count_dict, then='event__id'),
+                    When(then='event__id', **event_count_dict),
                     output_field=IntegerField()
                 ), distinct=True)
             else:


### PR DESCRIPTION
Address comments in #338. Match order of arguments for `When` in Django documentation https://docs.djangoproject.com/en/2.0/ref/models/conditional-expressions/ and preserve Python 3.4 compatibility