### PR TITLE
Specify older versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 django<1.9
 configobj
 django-admin-bootstrapped
-django-phonenumber-field
-django-autocomplete-light<3
+django-phonenumber-field<2
+django-autocomplete-light<2.3.4
 django-watson
 phonenumbers
 psycopg2


### PR DESCRIPTION
Because the django specified is a little older, some of the other dependencies in requirements.txt fail when working in tandem with it.  This is due to new versions coming out that have runtime dependencies
on newer django versions.

Without this, the application fails to boot.