### PR TITLE
Fix #343: Add Export of All Participants

### DIFF
--- a/streetcrm/admin.py
+++ b/streetcrm/admin.py
@@ -755,7 +755,7 @@ class LeaderGrowthInline(admin.TabularInline):
     verbose_name_plural = "Leader Stages"
     readonly_fields = ("date_reached", )
     
-class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, SearchAdmin):
+class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, mixins.AdminExportMixin, SearchAdmin):
     """ Admin UI for participant including listing event history """
     search_fields = ("name", "primary_phone", "title", "email",
                      "participant_street_address",
@@ -790,6 +790,25 @@ class ParticipantAdmin(mixins.AdminArchiveMixin, mixins.SignInSheetAdminMixin, S
         }),
     )
     import_path = reverse_lazy("import-participants")
+
+    export_header = [
+            {"column": "id", "heading": "ID"},
+            {"column": "name", "heading": "Participant name"},
+            {"column": "primary_phone", "heading": "Phone number"},
+            {"column": "secondary_phone", "heading": "Secondary Phone"},
+            {"column": "email", "heading": "Email address"},
+            {"column": "participant_street_address", "heading":
+            "Address"},
+            {"column": "participant_city_address", "heading":
+            "City"},
+            {"column": "participant_state_address", "heading":
+            "State"},
+            {"column": "participant_zipcode_address", "heading":
+            "Zip"},
+            {"column": "institution_id", "heading": "Institution"},
+            {"column": "title", "heading": "Title"},
+            {"column": "leadership", "heading": "Leadership level"}
+        ]
 
     inlines = [LeaderGrowthInline,]
 

--- a/streetcrm/models.py
+++ b/streetcrm/models.py
@@ -246,6 +246,8 @@ class Participant(ArchiveAbstract, SerializeableMixin):
     class Meta:
         ordering = ['name']
 
+    # When adding fields here, also make sure to add them to the spreadsheet output
+    # in the admin.ParticipantAdmin export_header field
     name = models.CharField(max_length=255, verbose_name="Participant Name")
     primary_phone = modelfields.PhoneNumberField(null=True, blank=True,
                                                  verbose_name="Participant Phone")

--- a/streetcrm/static/css/streetcrm.css
+++ b/streetcrm/static/css/streetcrm.css
@@ -690,6 +690,15 @@ h2#stages-header:hover {
   padding: 15px;
 }
 
+.navbar-nav li > a.btn-export {
+  margin-left: 10px;
+}
+
+.navbar-nav li a.btn-export:hover {
+  background-color: #e6e6e6 !important;
+  border-color: #adadad !important;
+}
+
 #toast {
   display: none;
   position: fixed;

--- a/streetcrm/templates/admin/change_list.html
+++ b/streetcrm/templates/admin/change_list.html
@@ -76,6 +76,13 @@
             </label>
         </li>
         {% endif %}
+        {% if export_link %}
+        <li>
+          <a role="button" href="{% url export_link %}" class="btn-export btn-default btn">
+              {% blocktrans with cl.opts.verbose_name as name %}Export {{ name }} list{% endblocktrans %}
+          </a>
+        </li>
+        {% endif %}
         {% endif %}
         {% endblock %}
     </ul>


### PR DESCRIPTION
Added a mixin for different Admin pages to be able to export, and enabled for the ParticipantAdmin.

Decided to go the mixin route in case someone asks for export of other admin interfaces, this makes those changes a simple mixin addition.

Need #347 to land before you can test this.