### PR TITLE
Fix #340: Breadcrumb links disappear on hover

### DIFF
--- a/streetcrm/static/css/streetcrm.css
+++ b/streetcrm/static/css/streetcrm.css
@@ -160,6 +160,10 @@ a:focus,
     color: white;
 }
 
+.breadcrumb a:hover {
+    color: white;
+}
+
 #search-form {
     width: 35%;
     padding: 0px;


### PR DESCRIPTION
Add a new rule for breadcrumb css to make a:hover white as well.  Added
the new rule instead of removing the rule that affected this on hover
because that rule is part of the theme code in base.html, and special
casing when a theme shouldn't be applied is better than special casing
when it should.