### PR TITLE
Update css to make password link more pronounced.

### DIFF
--- a/streetcrm/static/css/streetcrm.css
+++ b/streetcrm/static/css/streetcrm.css
@@ -338,6 +338,19 @@ value. */
     clear: both;
 }
 
+/* Special hover formatting for links in help blocks */
+.help-block a {
+    text-decoration: underline;
+    padding: 2px;
+    margin-left: -2px;
+    margin-right: -2px;
+    border: 2px solid transparent;
+}
+
+.help-block a:hover {
+    border: 2px solid #1e6b27;
+}
+
 /* Hide the "save an add another" and "save and continue editing" buttons */
 input[name="_addanother"],input[name="_continue"],input[name="_saveasnew"]{
     display: none;

--- a/streetcrm/templates/admin/base.html
+++ b/streetcrm/templates/admin/base.html
@@ -40,6 +40,10 @@
 			#toggle_more_actions {
 				color: {{ theme_color }};
 			}
+
+      .help-block a:hover {
+        border: 2px solid {{ theme_color }};
+      }
 			
 			#actual-navbar,
 			#content .hr {


### PR DESCRIPTION
When looking at text in user update change, the password link was
getting lost, especially in some themes.  The change was to make
the link underlined all the time, and be surrounded by a box when not
underlined.

Issue #246: Fix link colors to distinguish them from non-link text