### PR TITLE
Fix #344: add an "Any Leadership Level" choice

### DIFF
--- a/streetcrm/forms.py
+++ b/streetcrm/forms.py
@@ -211,7 +211,11 @@ class SearchForm(django.forms.Form):
     exclude_major_events = django.forms.BooleanField(required=False)
     exclude_minor_events = django.forms.BooleanField(required=False)
 
-    leader_stage = django.forms.ModelChoiceField(queryset=models.LeaderStage.objects, required=False)
+    leader_stage = django.forms.ModelChoiceField(
+        queryset=models.LeaderStage.objects.all(),
+        empty_label="Any Leadership Level",
+        required=False
+    )
     start_date = django.forms.DateField(
         required=False,
         widget=AdminDateWidget()


### PR DESCRIPTION
The empty choice was already the any leadership level choice, so just a
label change was all that was needed.